### PR TITLE
Quanta fix: Mood remove option missing

### DIFF
--- a/src/app/page.js
+++ b/src/app/page.js
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect, useRef } from 'react';
-import { Smile, Palette, Heart, RotateCw } from 'lucide-react';
+import { Smile, Palette, Heart, RotateCw, Trash2 } from 'lucide-react';
 
 export default function MoodArtApp() {
   const [currentMode, setCurrentMode] = useState('mood');
@@ -45,6 +45,11 @@ export default function MoodArtApp() {
     };
     setMoodHistory(prev => [newMood, ...prev]);
     setMoodCount(prev => prev + 1);
+  };
+
+  const removeMood = (id) => {
+    setMoodHistory(prev => prev.filter(mood => mood.id !== id));
+    setMoodCount(prev => Math.max(0, prev - 1));
   };
 
   // Art Functions
@@ -186,6 +191,13 @@ export default function MoodArtApp() {
                     <div className="text-sm font-medium text-white">{mood.label}</div>
                     <div className="text-xs text-white/60">{mood.timestamp}</div>
                   </div>
+                  <button
+                    onClick={() => removeMood(mood.id)}
+                    className="text-white/60 hover:text-red-400 transition-colors"
+                    aria-label="Delete mood"
+                  >
+                    <Trash2 className="w-5 h-5" />
+                  </button>
                 </div>
               ))}
             </div>


### PR DESCRIPTION
> 🤖 Draft PR generated by **Quanta** — review before merging.

## Bug
Mood remove option missing ([view feedback](http://localhost:3000/projects/rectify-test/feedback/6a42325ef3cf7b49481a9cac))

## Triage summary
Users are unable to delete or remove logged moods from their Mood History list because neither a deletion handler function nor a delete control/button is implemented in the UI. This prevents correcting mistakes or clearing old logs.

**Likely root cause:** The `MoodArtApp` component in `src/app/page.js` manages mood history with the `moodHistory` state array but lacks a function to delete entries (e.g., `removeMood`) and a corresponding delete button within each rendered list item.

## What Quanta changed
_No summary provided by the fix agent_