### PR TITLE
Quanta fix: More moods option needed

### DIFF
--- a/src/app/page.js
+++ b/src/app/page.js
@@ -25,6 +25,9 @@ export default function MoodArtApp() {
     { emoji: '😤', label: 'Angry', color: 'bg-orange-500' },
     { emoji: '😢', label: 'Sad', color: 'bg-indigo-400' },
     { emoji: '😴', label: 'Tired', color: 'bg-purple-400' },
+    { emoji: '🤩', label: 'Excited', color: 'bg-pink-400' },
+    { emoji: '🤔', label: 'Thoughtful', color: 'bg-teal-400' },
+    { emoji: '😰', label: 'Anxious', color: 'bg-emerald-500' },
   ];
 
   useEffect(() => {


### PR DESCRIPTION
> 🤖 Draft PR generated by **Quanta** — review before merging.

## Bug
More moods option needed ([view feedback](http://localhost:3000/projects/rectify-test/feedback/6a414f30d1c3b30e9738cff9))

## Triage summary
The application currently limits users to selecting from only 6 default mood options in the Mood Tracker grid. This is a feature request to expand the variety of emotional options to allow users to record their mood more accurately.

**Likely root cause:** The set of mood options is hardcoded as an array of 6 elements inside the MoodArtApp component in src/app/page.js, offering no additional selections to the user.

## What Quanta changed
_No summary provided by the fix agent_