### PR TITLE
Quanta fix: More moods option needed

### DIFF
--- a/src/app/page.js
+++ b/src/app/page.js
@@ -25,6 +25,9 @@ export default function MoodArtApp() {
     { emoji: '😤', label: 'Angry', color: 'bg-orange-500' },
     { emoji: '😢', label: 'Sad', color: 'bg-indigo-400' },
     { emoji: '😴', label: 'Tired', color: 'bg-purple-400' },
+    { emoji: '🥳', label: 'Excited', color: 'bg-pink-500' },
+    { emoji: '😰', label: 'Anxious', color: 'bg-teal-500' },
+    { emoji: '😎', label: 'Cool', color: 'bg-emerald-500' },
   ];
 
   useEffect(() => {


### PR DESCRIPTION
> 🤖 Draft PR generated by **Quanta**. Review it before merging.

## Bug
More moods option needed ([view feedback](http://localhost:3000/projects/rectify-test/feedback/6a414f30d1c3b30e9738cff9))

## Triage summary
The user is requesting additional mood tracking options because there are currently only six moods available in the application. Adding more choices, such as Excited, Anxious, or Cool, will improve tracking variety and user engagement.

**Likely root cause:** The moods array is statically defined with only six options inside the main component, limiting the user choices to those specific items.

## What Quanta changed
_No summary provided by the fix agent_